### PR TITLE
build: replace `appstream-utils` with `appstreamcli`, according to th…

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -29,9 +29,9 @@ appstream_file = i18n.merge_file(
   install_dir: join_paths(get_option('datadir'), 'metainfo')
 )
 
-appstream_util = find_program('appstream-util', required: false)
-if appstream_util.found()
-  test('Validate appstream file', appstream_util, args: ['validate', appstream_file])
+appstreamcli = find_program('appstreamcli', required: false)
+if appstreamcli.found()
+  test('Validate appstream file', appstreamcli, args: ['validate', appstream_file])
 endif
 
 install_data('io.github.nokse22.asciidraw.gschema.xml',


### PR DESCRIPTION
`appstream-utils` did not allow the tests to pass, because of the images padding. Flathub has changed the utility for checking appdata files. 

Link: https://github.com/flathub-infra/flatpak-builder-lint/commit/bbfc701d87c53d6336febf6d4e1121dad424f367