### PR TITLE
Add Serbian translations (Cyrillic & Latin)

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -7,3 +7,5 @@ tr
 pt_BR
 zh
 vi
+sr
+sr@latin

--- a/po/sr.po
+++ b/po/sr.po
@@ -1,0 +1,570 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-04 15:09+0200\n"
+"PO-Revision-Date: 2026-03-22 12:08+0100\n"
+"Last-Translator: Radoš Milićev <https://github.com/rammba>\n"
+"Language-Team: \n"
+"Language: sr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.8\n"
+
+#: data/io.github.nokse22.asciidraw.desktop.in:2
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:3 src/ui/window.ui:51
+#: src/main.py:153
+msgid "ASCII Draw"
+msgstr "ASCII Draw"
+
+#: data/io.github.nokse22.asciidraw.desktop.in:8
+msgid "GNOME;GTK;Graphics;Art;"
+msgstr "GNOME;GTK;Graphics;Art;"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:10
+msgid "Sketch anything using characters"
+msgstr "Нацртајте било шта користећи карактере"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:13
+msgid ""
+"Draw diagrams, tables, tree view, art and more using only characters. There "
+"are many tools and features available such as:"
+msgstr ""
+"Цртајте дијаграме, табеле, структуру стабла, уметности и још много тога "
+"користећи само карактере. Постоји много алата и функционалности као што су:"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:16
+msgid "Rectangle using multiple line styles"
+msgstr "Правоугаоник користећи различите стилове линија"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:17
+msgid "Filled Rectangle using border and fill characters"
+msgstr "Попуњени правоугаоник користећи карактере за ивице и попуњавање"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:18
+msgid "Cartesian, Freehand and Stepped line, also with arrows"
+msgstr "Декартове, слободно цртане и степенасте линије, и то са стрелицама"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:19
+msgid "Freehand Brush"
+msgstr "Четка за слободно цртање"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:20
+msgid "Text with FIGlet fonts"
+msgstr "Текст са FIGlet фонтовима"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:21
+#: src/ui/table_sidebar.ui:114 src/tools/table.py:116
+msgid "Table"
+msgstr "Табела"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:22
+msgid "Tree View"
+msgstr "Структура стабла"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:23
+#: src/ui/eraser_sidebar.ui:41 src/tools/eraser.py:73
+msgid "Eraser"
+msgstr "Гумица"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:24
+msgid "Character Picker"
+msgstr "Бирач карактера"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:25
+msgid "Move and Rotate selection"
+msgstr "Померање и ротирање одабира"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:26
+msgid "Flood Fill"
+msgstr "Попуњавање"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:204
+msgid "ASCII Art of an old television"
+msgstr "ASCII уметност старог телевизора"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:209
+msgid "CPU simplified structure"
+msgstr "Поједностављена структура процесора"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:214
+msgid "Table of countries, capitals and population"
+msgstr "Табела држава, главних градова и популације"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:219
+msgid "A flowchart to fix a lamp"
+msgstr "Дијаграм тока за поправку лампе"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:224
+msgid "An example of a treeview"
+msgstr "Пример структуре стабла"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:229
+msgid "Cartesian, stepped and freehand lines"
+msgstr "Декартове, степенасте и слободно цртане линије"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:234
+msgid "Move and Rotate Tool"
+msgstr "Алат за померање и ротирање"
+
+#: src/shortcuts-dialog.ui:11
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Опште"
+
+#: src/shortcuts-dialog.ui:14
+msgctxt "shortcut window"
+msgid "Show Shortcuts"
+msgstr "Прикажи пречице"
+
+#: src/shortcuts-dialog.ui:26
+msgctxt "shortcut window"
+msgid "Save"
+msgstr "Сачувај"
+
+#: src/shortcuts-dialog.ui:32
+msgctxt "shortcut window"
+msgid "Save As"
+msgstr "Сачувај као"
+
+#: src/shortcuts-dialog.ui:38
+msgctxt "shortcut window"
+msgid "Open"
+msgstr "Отвори"
+
+#: src/shortcuts-dialog.ui:44
+msgctxt "shortcut window"
+msgid "New Canvas"
+msgstr "Ново платно"
+
+#: src/shortcuts-dialog.ui:50
+msgctxt "shortcut window"
+msgid "Undo"
+msgstr "Опозови"
+
+#: src/shortcuts-dialog.ui:56
+msgctxt "shortcut window"
+msgid "Redo"
+msgstr "Понови"
+
+#: src/shortcuts-dialog.ui:64
+msgctxt "shortcut window"
+msgid "Tools"
+msgstr "Алати"
+
+#: src/shortcuts-dialog.ui:67
+msgctxt "shortcut window"
+msgid "Rectangle"
+msgstr "Правоугаоник"
+
+#: src/shortcuts-dialog.ui:73
+msgctxt "shortcut window"
+msgid "Filled Rectangle"
+msgstr "Попуњени правоугаоник"
+
+#: src/shortcuts-dialog.ui:79
+msgctxt "shortcut window"
+msgid "Line"
+msgstr "Линија"
+
+#: src/shortcuts-dialog.ui:85
+msgctxt "shortcut window"
+msgid "Freehand Brush"
+msgstr "Четка за слободно цртање"
+
+#: src/shortcuts-dialog.ui:91
+msgctxt "shortcut window"
+msgid "Text"
+msgstr "Текст"
+
+#: src/shortcuts-dialog.ui:97
+msgctxt "shortcut window"
+msgid "Table"
+msgstr "Табела"
+
+#: src/shortcuts-dialog.ui:103
+msgctxt "shortcut window"
+msgid "Tree View"
+msgstr "Структура стабла"
+
+#: src/shortcuts-dialog.ui:109
+msgctxt "shortcut window"
+msgid "Eraser"
+msgstr "Гумица"
+
+#: src/shortcuts-dialog.ui:115
+msgctxt "shortcut window"
+msgid "Picker"
+msgstr "Бирач"
+
+#: src/shortcuts-dialog.ui:121
+msgctxt "shortcut window"
+msgid "Move"
+msgstr "Помери"
+
+#: src/shortcuts-dialog.ui:127
+msgctxt "shortcut window"
+msgid "Fill"
+msgstr "Попуни"
+
+#: src/ui/new_palette.ui:10
+msgid "New palette"
+msgstr "Нова палета"
+
+#: src/ui/new_palette.ui:38
+msgid "Palette name"
+msgstr "Назив палете"
+
+#: src/ui/new_palette.ui:70 src/ui/window.ui:56 src/main.py:187 src/main.py:208
+#: src/window.py:433
+msgid "Save"
+msgstr "Сачувај"
+
+#: src/ui/window.ui:65 src/window.py:659
+msgid "Undo"
+msgstr "Опозови"
+
+#: src/ui/window.ui:73
+msgid "Redo"
+msgstr "Понови"
+
+#: src/ui/window.ui:80
+msgid "Toggle Sidebar"
+msgstr "Укљ/Искљ бочну траку"
+
+#: src/ui/window.ui:100
+msgid "Rectangle Ctrl+R"
+msgstr "Правоугаоник Ctrl+R"
+
+#: src/ui/window.ui:112
+msgid "Filled rectangle Ctrl+Shift+R"
+msgstr "Попуњени правоугаоник Ctrl+Shift+R"
+
+#: src/ui/window.ui:124
+msgid "Line Ctrl+L"
+msgstr "Линија Ctrl+L"
+
+#: src/ui/window.ui:136
+msgid "Freehand Ctrl+F"
+msgstr "Слободно цртање Ctrl+F"
+
+#: src/ui/window.ui:148
+msgid "Text Ctrl+T"
+msgstr "Текст Ctrl+T"
+
+#: src/ui/window.ui:165
+msgid "Table Ctrl+Shift+T"
+msgstr "Табела Ctrl+Shift+T"
+
+#: src/ui/window.ui:177
+msgid "Tree view Ctrl+U"
+msgstr "Структура стабла Ctrl+U"
+
+#: src/ui/window.ui:189
+msgid "Eraser Ctrl+E"
+msgstr "Гумица Ctrl+E"
+
+#: src/ui/window.ui:201
+msgid "Picker Ctrl+P"
+msgstr "Бирач Ctrl+P"
+
+#: src/ui/window.ui:213
+msgid "Move Ctrl+M"
+msgstr "Помери Ctrl+M"
+
+#: src/ui/window.ui:225
+msgid "Fill Ctrl+Shift+F"
+msgstr "Попуни Ctrl+Shift+F"
+
+#: src/ui/window.ui:238
+msgid "Primary Character"
+msgstr "Примарни карактер"
+
+#: src/ui/window.ui:249
+msgid "Secondary Character"
+msgstr "Секундарни карактер"
+
+#: src/ui/window.ui:273
+msgid "Close Sidebar"
+msgstr "Затвори бочну траку"
+
+#: src/ui/window.ui:280
+msgid "Main Menu"
+msgstr "Главни мени"
+
+#: src/ui/window.ui:287
+msgid "Resize Canvas"
+msgstr "Промени величину платна"
+
+#: src/ui/window.ui:306
+msgid "Width"
+msgstr "Ширина"
+
+#: src/ui/window.ui:321
+msgid "Height"
+msgstr "Висина"
+
+#: src/ui/window.ui:326
+msgid "Change size"
+msgstr "Промени величину"
+
+#: src/ui/window.ui:368
+msgid "ASCII"
+msgstr "ASCII"
+
+#: src/ui/window.ui:390
+msgid "Character"
+msgstr "Карактер"
+
+#: src/ui/window.ui:413
+msgid "Style"
+msgstr "Стил"
+
+#: src/ui/window.ui:445
+msgid "Clear Canvas"
+msgstr "Очисти платно"
+
+#: src/ui/window.ui:451
+msgid "New Palette"
+msgstr "Нова палета"
+
+#: src/ui/window.ui:455
+msgid "New Palette From Canvas"
+msgstr "Нова палета са платна"
+
+#: src/ui/window.ui:459
+msgid "Open Palettes Folder"
+msgstr "Отвори фолдер са палетама"
+
+#: src/ui/window.ui:465
+msgid "Keyboard Shortcuts"
+msgstr "Пречице на тастатури"
+
+#: src/ui/window.ui:469
+msgid "About ASCII Draw"
+msgstr "О ASCII Draw"
+
+#: src/ui/window.ui:479
+msgid "Copy To Clipboard"
+msgstr "Копирај у clipboard"
+
+#: src/ui/window.ui:483
+msgid "Save As"
+msgstr "Сачувај као"
+
+#: src/ui/window.ui:489
+msgid "Open"
+msgstr "Отвори"
+
+#: src/ui/window.ui:493 src/window.py:468
+msgid "New Canvas"
+msgstr "Ново платно"
+
+#: src/ui/eraser_sidebar.ui:17 src/ui/freehand_sidebar.ui:17
+msgid "Size"
+msgstr "Величина"
+
+#: src/ui/freehand_sidebar.ui:41 src/ui/line_sidebar.ui:21
+#: src/tools/freehand.py:70
+msgid "Freehand"
+msgstr "Слободно цртање"
+
+#: src/ui/line_sidebar.ui:19
+msgid "Cartesian"
+msgstr "Декартово"
+
+#: src/ui/line_sidebar.ui:20
+msgid "Step"
+msgstr "Степенасто"
+
+#: src/ui/line_sidebar.ui:26 src/ui/table_sidebar.ui:91
+msgid "Type"
+msgstr "Тип"
+
+#: src/ui/line_sidebar.ui:31
+msgid "Arrow"
+msgstr "Стрелица"
+
+#: src/ui/line_sidebar.ui:38
+msgid "Line"
+msgstr "Линија"
+
+#: src/ui/move_sidebar.ui:20 src/tools/select.py:291
+msgid "Rotate"
+msgstr "Ротирај"
+
+#: src/ui/move_sidebar.ui:43
+msgid "Copy"
+msgstr "Копирај"
+
+#: src/ui/move_sidebar.ui:61
+msgid "Delete"
+msgstr "Избриши"
+
+#: src/ui/move_sidebar.ui:81
+msgid "Press CTRL and move to duplicate"
+msgstr "Притисни CTRL и померај да дуплираш"
+
+#: src/ui/move_sidebar.ui:89 src/tools/select.py:132
+msgid "Move"
+msgstr "Помери"
+
+#: src/ui/table_sidebar.ui:28
+msgid "Columns"
+msgstr "Колоне"
+
+#: src/ui/table_sidebar.ui:34
+msgid "Rows"
+msgstr "Редови"
+
+#: src/ui/table_sidebar.ui:43
+msgid "Add a row"
+msgstr "Додај ред"
+
+#: src/ui/table_sidebar.ui:50
+msgid "Delete rows"
+msgstr "Избриши редове"
+
+#: src/ui/table_sidebar.ui:84
+msgid "First line divided"
+msgstr "Прва линија подељена"
+
+#: src/ui/table_sidebar.ui:85
+msgid "Divide each row"
+msgstr "Подели сваки ред"
+
+#: src/ui/table_sidebar.ui:86
+msgid "Not divided"
+msgstr "Без поделе"
+
+#: src/ui/table_sidebar.ui:102 src/ui/text_sidebar.ui:75
+#: src/ui/tree_sidebar.ui:44
+msgid "Enter"
+msgstr "Унеси"
+
+#: src/ui/text_sidebar.ui:47
+msgid "Choose Font"
+msgstr "Изабери фонт"
+
+#: src/ui/text_sidebar.ui:58
+msgid "Vertical Text"
+msgstr "Вертикални текст"
+
+#: src/ui/text_sidebar.ui:63
+msgid "Spaces do not overwrite"
+msgstr "Размаци не замењују"
+
+#: src/ui/text_sidebar.ui:64
+msgid "Transparent spaces"
+msgstr "Провидни размаци"
+
+#: src/ui/text_sidebar.ui:115 src/main.py:185 src/main.py:206 src/window.py:431
+msgid "Cancel"
+msgstr "Откажи"
+
+#: src/ui/text_sidebar.ui:121
+msgid "Select"
+msgstr "Изабери"
+
+#: src/ui/text_sidebar.ui:137 src/tools/text.py:187
+msgid "Text"
+msgstr "Текст"
+
+#: src/ui/tree_sidebar.ui:56
+msgid "Tree view"
+msgstr "Структура стабла"
+
+#: src/main.py:106
+msgid "Clear"
+msgstr "Очисти"
+
+#: src/main.py:164
+msgid "translator-credits"
+msgstr "Radoš Milićev: https://github.com/rammba"
+
+#: src/main.py:178
+msgid "Save File?"
+msgstr "Сачувај датотеку?"
+
+#: src/main.py:179
+msgid ""
+"You have never saved this file. Changes which are not saved will be "
+"permanently lost."
+msgstr ""
+"Никада нисте сачували ову датотеку. Измене које нису сачуване ће бити "
+"изгубљене."
+
+#: src/main.py:186 src/main.py:207 src/window.py:432
+msgid "Discard"
+msgstr "Одбаци"
+
+#: src/main.py:199
+msgid "Save changes?"
+msgstr "Сачувај измене?"
+
+#: src/main.py:200 src/window.py:427
+msgid ""
+"The opened file contains unsaved changes. Changes which are not saved will "
+"be permanently lost."
+msgstr ""
+"Отворена датотека садржи измене које нису сачуване. Измене које нису "
+"сачуване ће бити изгубљене."
+
+#: src/tools/filled_rectangle.py:120
+msgid "Filled Rectangle"
+msgstr "Попуњени правоугаоник"
+
+#: src/tools/line.py:105
+msgid "Freehand Line"
+msgstr "Слободно цртана линија"
+
+#: src/tools/line.py:159
+msgid "Cartesian Line"
+msgstr "Декартова линија"
+
+#: src/tools/line.py:164
+msgid "Step Line"
+msgstr "Степенаста линија"
+
+#: src/tools/rectangle.py:112
+msgid "Rectangle"
+msgstr "Правоугаоник"
+
+#: src/tools/tree.py:150
+msgid "Tree"
+msgstr "Стабло"
+
+#: src/window.py:398
+msgid "Open File"
+msgstr "Отвори датотеку"
+
+#: src/window.py:426
+msgid "Save Changes?"
+msgstr "Сачувај измене?"
+
+#: src/window.py:476
+msgid "Save File"
+msgstr "Сачувај датотеку"
+
+#: src/window.py:477
+msgid "drawing.txt"
+msgstr "drawing.txt"
+
+#: src/window.py:504
+msgid "Saved successfully"
+msgstr "Успешно чување"
+
+#: src/window.py:667
+msgid "Undo "
+msgstr "Опозови "
+
+#: src/window.py:671 src/window.py:679
+msgid "Redo "
+msgstr "Понови "

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -1,0 +1,570 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-04 15:09+0200\n"
+"PO-Revision-Date: 2026-03-22 12:14+0100\n"
+"Last-Translator: Radoš Milićev <https://github.com/rammba>\n"
+"Language-Team: \n"
+"Language: sr@latin\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.8\n"
+
+#: data/io.github.nokse22.asciidraw.desktop.in:2
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:3 src/ui/window.ui:51
+#: src/main.py:153
+msgid "ASCII Draw"
+msgstr "ASCII Draw"
+
+#: data/io.github.nokse22.asciidraw.desktop.in:8
+msgid "GNOME;GTK;Graphics;Art;"
+msgstr "GNOME;GTK;Graphics;Art;"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:10
+msgid "Sketch anything using characters"
+msgstr "Nacrtajte bilo šta koristeći karaktere"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:13
+msgid ""
+"Draw diagrams, tables, tree view, art and more using only characters. There "
+"are many tools and features available such as:"
+msgstr ""
+"Crtajte dijagrame, tabele, strukturu stabla, umetnosti i još mnogo toga "
+"koristeći samo karaktere. Postoji mnogo alata i funkcionalnosti kao što su:"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:16
+msgid "Rectangle using multiple line styles"
+msgstr "Pravougaonik koristeći različite stilove linija"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:17
+msgid "Filled Rectangle using border and fill characters"
+msgstr "Popunjeni pravougaonik koristeći karaktere za ivice i popunjavanje"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:18
+msgid "Cartesian, Freehand and Stepped line, also with arrows"
+msgstr "Dekartove, slobodno crtane i stepenaste linije, i to sa strelicama"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:19
+msgid "Freehand Brush"
+msgstr "Četka za slobodno crtanje"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:20
+msgid "Text with FIGlet fonts"
+msgstr "Tekst sa FIGlet fontovima"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:21
+#: src/ui/table_sidebar.ui:114 src/tools/table.py:116
+msgid "Table"
+msgstr "Tabela"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:22
+msgid "Tree View"
+msgstr "Struktura stabla"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:23
+#: src/ui/eraser_sidebar.ui:41 src/tools/eraser.py:73
+msgid "Eraser"
+msgstr "Gumica"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:24
+msgid "Character Picker"
+msgstr "Birač karaktera"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:25
+msgid "Move and Rotate selection"
+msgstr "Pomeranje i rotiranje odabira"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:26
+msgid "Flood Fill"
+msgstr "Popunjavanje"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:204
+msgid "ASCII Art of an old television"
+msgstr "ASCII umetnost starog televizora"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:209
+msgid "CPU simplified structure"
+msgstr "Pojednostavljena struktura procesora"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:214
+msgid "Table of countries, capitals and population"
+msgstr "Tabela država, glavnih gradova i populacije"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:219
+msgid "A flowchart to fix a lamp"
+msgstr "Dijagram toka za popravku lampe"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:224
+msgid "An example of a treeview"
+msgstr "Primer strukture stabla"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:229
+msgid "Cartesian, stepped and freehand lines"
+msgstr "Dekartove, stepenaste i slobodno crtane linije"
+
+#: data/io.github.nokse22.asciidraw.metainfo.xml.in:234
+msgid "Move and Rotate Tool"
+msgstr "Alat za pomeranje i rotiranje"
+
+#: src/shortcuts-dialog.ui:11
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Opšte"
+
+#: src/shortcuts-dialog.ui:14
+msgctxt "shortcut window"
+msgid "Show Shortcuts"
+msgstr "Prikaži prečice"
+
+#: src/shortcuts-dialog.ui:26
+msgctxt "shortcut window"
+msgid "Save"
+msgstr "Sačuvaj"
+
+#: src/shortcuts-dialog.ui:32
+msgctxt "shortcut window"
+msgid "Save As"
+msgstr "Sačuvaj kao"
+
+#: src/shortcuts-dialog.ui:38
+msgctxt "shortcut window"
+msgid "Open"
+msgstr "Otvori"
+
+#: src/shortcuts-dialog.ui:44
+msgctxt "shortcut window"
+msgid "New Canvas"
+msgstr "Novo platno"
+
+#: src/shortcuts-dialog.ui:50
+msgctxt "shortcut window"
+msgid "Undo"
+msgstr "Opozovi"
+
+#: src/shortcuts-dialog.ui:56
+msgctxt "shortcut window"
+msgid "Redo"
+msgstr "Ponovi"
+
+#: src/shortcuts-dialog.ui:64
+msgctxt "shortcut window"
+msgid "Tools"
+msgstr "Alati"
+
+#: src/shortcuts-dialog.ui:67
+msgctxt "shortcut window"
+msgid "Rectangle"
+msgstr "Pravougaonik"
+
+#: src/shortcuts-dialog.ui:73
+msgctxt "shortcut window"
+msgid "Filled Rectangle"
+msgstr "Popunjeni pravougaonik"
+
+#: src/shortcuts-dialog.ui:79
+msgctxt "shortcut window"
+msgid "Line"
+msgstr "Linija"
+
+#: src/shortcuts-dialog.ui:85
+msgctxt "shortcut window"
+msgid "Freehand Brush"
+msgstr "Četka za slobodno crtanje"
+
+#: src/shortcuts-dialog.ui:91
+msgctxt "shortcut window"
+msgid "Text"
+msgstr "Tekst"
+
+#: src/shortcuts-dialog.ui:97
+msgctxt "shortcut window"
+msgid "Table"
+msgstr "Tabela"
+
+#: src/shortcuts-dialog.ui:103
+msgctxt "shortcut window"
+msgid "Tree View"
+msgstr "Struktura stabla"
+
+#: src/shortcuts-dialog.ui:109
+msgctxt "shortcut window"
+msgid "Eraser"
+msgstr "Gumica"
+
+#: src/shortcuts-dialog.ui:115
+msgctxt "shortcut window"
+msgid "Picker"
+msgstr "Birač"
+
+#: src/shortcuts-dialog.ui:121
+msgctxt "shortcut window"
+msgid "Move"
+msgstr "Pomeri"
+
+#: src/shortcuts-dialog.ui:127
+msgctxt "shortcut window"
+msgid "Fill"
+msgstr "Popuni"
+
+#: src/ui/new_palette.ui:10
+msgid "New palette"
+msgstr "Nova paleta"
+
+#: src/ui/new_palette.ui:38
+msgid "Palette name"
+msgstr "Naziv palete"
+
+#: src/ui/new_palette.ui:70 src/ui/window.ui:56 src/main.py:187 src/main.py:208
+#: src/window.py:433
+msgid "Save"
+msgstr "Sačuvaj"
+
+#: src/ui/window.ui:65 src/window.py:659
+msgid "Undo"
+msgstr "Opozovi"
+
+#: src/ui/window.ui:73
+msgid "Redo"
+msgstr "Ponovi"
+
+#: src/ui/window.ui:80
+msgid "Toggle Sidebar"
+msgstr "Uklj/Isklj bočnu traku"
+
+#: src/ui/window.ui:100
+msgid "Rectangle Ctrl+R"
+msgstr "Pravougaonik Ctrl+R"
+
+#: src/ui/window.ui:112
+msgid "Filled rectangle Ctrl+Shift+R"
+msgstr "Popunjeni pravougaonik Ctrl+Shift+R"
+
+#: src/ui/window.ui:124
+msgid "Line Ctrl+L"
+msgstr "Linija Ctrl+L"
+
+#: src/ui/window.ui:136
+msgid "Freehand Ctrl+F"
+msgstr "Slobodno crtanje Ctrl+F"
+
+#: src/ui/window.ui:148
+msgid "Text Ctrl+T"
+msgstr "Tekst Ctrl+T"
+
+#: src/ui/window.ui:165
+msgid "Table Ctrl+Shift+T"
+msgstr "Tabela Ctrl+Shift+T"
+
+#: src/ui/window.ui:177
+msgid "Tree view Ctrl+U"
+msgstr "Struktura stabla Ctrl+U"
+
+#: src/ui/window.ui:189
+msgid "Eraser Ctrl+E"
+msgstr "Gumica Ctrl+E"
+
+#: src/ui/window.ui:201
+msgid "Picker Ctrl+P"
+msgstr "Birač Ctrl+P"
+
+#: src/ui/window.ui:213
+msgid "Move Ctrl+M"
+msgstr "Pomeri Ctrl+M"
+
+#: src/ui/window.ui:225
+msgid "Fill Ctrl+Shift+F"
+msgstr "Popuni Ctrl+Shift+F"
+
+#: src/ui/window.ui:238
+msgid "Primary Character"
+msgstr "Primarni karakter"
+
+#: src/ui/window.ui:249
+msgid "Secondary Character"
+msgstr "Sekundarni karakter"
+
+#: src/ui/window.ui:273
+msgid "Close Sidebar"
+msgstr "Zatvori bočnu traku"
+
+#: src/ui/window.ui:280
+msgid "Main Menu"
+msgstr "Glavni meni"
+
+#: src/ui/window.ui:287
+msgid "Resize Canvas"
+msgstr "Promeni veličinu platna"
+
+#: src/ui/window.ui:306
+msgid "Width"
+msgstr "Širina"
+
+#: src/ui/window.ui:321
+msgid "Height"
+msgstr "Visina"
+
+#: src/ui/window.ui:326
+msgid "Change size"
+msgstr "Promeni veličinu"
+
+#: src/ui/window.ui:368
+msgid "ASCII"
+msgstr "ASCII"
+
+#: src/ui/window.ui:390
+msgid "Character"
+msgstr "Karakter"
+
+#: src/ui/window.ui:413
+msgid "Style"
+msgstr "Stil"
+
+#: src/ui/window.ui:445
+msgid "Clear Canvas"
+msgstr "Očisti platno"
+
+#: src/ui/window.ui:451
+msgid "New Palette"
+msgstr "Nova paleta"
+
+#: src/ui/window.ui:455
+msgid "New Palette From Canvas"
+msgstr "Nova paleta sa platna"
+
+#: src/ui/window.ui:459
+msgid "Open Palettes Folder"
+msgstr "Otvori folder sa paletama"
+
+#: src/ui/window.ui:465
+msgid "Keyboard Shortcuts"
+msgstr "Prečice na tastaturi"
+
+#: src/ui/window.ui:469
+msgid "About ASCII Draw"
+msgstr "O ASCII Draw"
+
+#: src/ui/window.ui:479
+msgid "Copy To Clipboard"
+msgstr "Kopiraj u clipboard"
+
+#: src/ui/window.ui:483
+msgid "Save As"
+msgstr "Sačuvaj kao"
+
+#: src/ui/window.ui:489
+msgid "Open"
+msgstr "Otvori"
+
+#: src/ui/window.ui:493 src/window.py:468
+msgid "New Canvas"
+msgstr "Novo platno"
+
+#: src/ui/eraser_sidebar.ui:17 src/ui/freehand_sidebar.ui:17
+msgid "Size"
+msgstr "Veličina"
+
+#: src/ui/freehand_sidebar.ui:41 src/ui/line_sidebar.ui:21
+#: src/tools/freehand.py:70
+msgid "Freehand"
+msgstr "Slobodno crtanje"
+
+#: src/ui/line_sidebar.ui:19
+msgid "Cartesian"
+msgstr "Dekartovo"
+
+#: src/ui/line_sidebar.ui:20
+msgid "Step"
+msgstr "Stepenasto"
+
+#: src/ui/line_sidebar.ui:26 src/ui/table_sidebar.ui:91
+msgid "Type"
+msgstr "Tip"
+
+#: src/ui/line_sidebar.ui:31
+msgid "Arrow"
+msgstr "Strelica"
+
+#: src/ui/line_sidebar.ui:38
+msgid "Line"
+msgstr "Linija"
+
+#: src/ui/move_sidebar.ui:20 src/tools/select.py:291
+msgid "Rotate"
+msgstr "Rotiraj"
+
+#: src/ui/move_sidebar.ui:43
+msgid "Copy"
+msgstr "Kopiraj"
+
+#: src/ui/move_sidebar.ui:61
+msgid "Delete"
+msgstr "Izbriši"
+
+#: src/ui/move_sidebar.ui:81
+msgid "Press CTRL and move to duplicate"
+msgstr "Pritisni CTRL i pomeraj da dupliraš"
+
+#: src/ui/move_sidebar.ui:89 src/tools/select.py:132
+msgid "Move"
+msgstr "Pomeri"
+
+#: src/ui/table_sidebar.ui:28
+msgid "Columns"
+msgstr "Kolone"
+
+#: src/ui/table_sidebar.ui:34
+msgid "Rows"
+msgstr "Redovi"
+
+#: src/ui/table_sidebar.ui:43
+msgid "Add a row"
+msgstr "Dodaj red"
+
+#: src/ui/table_sidebar.ui:50
+msgid "Delete rows"
+msgstr "Izbriši redove"
+
+#: src/ui/table_sidebar.ui:84
+msgid "First line divided"
+msgstr "Prva linija podeljena"
+
+#: src/ui/table_sidebar.ui:85
+msgid "Divide each row"
+msgstr "Podeli svaki red"
+
+#: src/ui/table_sidebar.ui:86
+msgid "Not divided"
+msgstr "Bez podele"
+
+#: src/ui/table_sidebar.ui:102 src/ui/text_sidebar.ui:75
+#: src/ui/tree_sidebar.ui:44
+msgid "Enter"
+msgstr "Unesi"
+
+#: src/ui/text_sidebar.ui:47
+msgid "Choose Font"
+msgstr "Izaberi font"
+
+#: src/ui/text_sidebar.ui:58
+msgid "Vertical Text"
+msgstr "Vertikalni tekst"
+
+#: src/ui/text_sidebar.ui:63
+msgid "Spaces do not overwrite"
+msgstr "Razmaci ne zamenjuju"
+
+#: src/ui/text_sidebar.ui:64
+msgid "Transparent spaces"
+msgstr "Providni razmaci"
+
+#: src/ui/text_sidebar.ui:115 src/main.py:185 src/main.py:206 src/window.py:431
+msgid "Cancel"
+msgstr "Otkaži"
+
+#: src/ui/text_sidebar.ui:121
+msgid "Select"
+msgstr "Izaberi"
+
+#: src/ui/text_sidebar.ui:137 src/tools/text.py:187
+msgid "Text"
+msgstr "Tekst"
+
+#: src/ui/tree_sidebar.ui:56
+msgid "Tree view"
+msgstr "Struktura stabla"
+
+#: src/main.py:106
+msgid "Clear"
+msgstr "Očisti"
+
+#: src/main.py:164
+msgid "translator-credits"
+msgstr "Radoš Milićev: https://github.com/rammba"
+
+#: src/main.py:178
+msgid "Save File?"
+msgstr "Sačuvaj datoteku?"
+
+#: src/main.py:179
+msgid ""
+"You have never saved this file. Changes which are not saved will be "
+"permanently lost."
+msgstr ""
+"Nikada niste sačuvali ovu datoteku. Izmene koje nisu sačuvane će biti "
+"izgubljene."
+
+#: src/main.py:186 src/main.py:207 src/window.py:432
+msgid "Discard"
+msgstr "Odbaci"
+
+#: src/main.py:199
+msgid "Save changes?"
+msgstr "Sačuvaj izmene?"
+
+#: src/main.py:200 src/window.py:427
+msgid ""
+"The opened file contains unsaved changes. Changes which are not saved will "
+"be permanently lost."
+msgstr ""
+"Otvorena datoteka sadrži izmene koje nisu sačuvane. Izmene koje nisu "
+"sačuvane će biti izgubljene."
+
+#: src/tools/filled_rectangle.py:120
+msgid "Filled Rectangle"
+msgstr "Popunjeni pravougaonik"
+
+#: src/tools/line.py:105
+msgid "Freehand Line"
+msgstr "Slobodno crtana linija"
+
+#: src/tools/line.py:159
+msgid "Cartesian Line"
+msgstr "Dekartova linija"
+
+#: src/tools/line.py:164
+msgid "Step Line"
+msgstr "Stepenasta linija"
+
+#: src/tools/rectangle.py:112
+msgid "Rectangle"
+msgstr "Pravougaonik"
+
+#: src/tools/tree.py:150
+msgid "Tree"
+msgstr "Stablo"
+
+#: src/window.py:398
+msgid "Open File"
+msgstr "Otvori datoteku"
+
+#: src/window.py:426
+msgid "Save Changes?"
+msgstr "Sačuvaj izmene?"
+
+#: src/window.py:476
+msgid "Save File"
+msgstr "Sačuvaj datoteku"
+
+#: src/window.py:477
+msgid "drawing.txt"
+msgstr "drawing.txt"
+
+#: src/window.py:504
+msgid "Saved successfully"
+msgstr "Uspešno čuvanje"
+
+#: src/window.py:667
+msgid "Undo "
+msgstr "Opozovi "
+
+#: src/window.py:671 src/window.py:679
+msgid "Redo "
+msgstr "Ponovi "


### PR DESCRIPTION
Hello @Nokse22, thanks for making this great tool.

As a native Serbian speaker and maintainer of translations for [Notepad++](https://github.com/notepad-plus-plus/notepad-plus-plus), [official React docs](https://github.com/reactjs/sr.react.dev) and other open-source projects I wanted to add Serbian here as well.

P.S. I'm planning to add translations for you other flathub apps as well.